### PR TITLE
PROP-0001 -- Runbook

### DIFF
--- a/planning/proposals/props/prop-0001.md
+++ b/planning/proposals/props/prop-0001.md
@@ -1,0 +1,65 @@
+<pre>
+    Title: PROP 1 -- Runbook
+    Author: @kvh
+    Status: Active
+</pre>
+
+
+## Runbook
+
+#### One click recipes to automate any web task
+
+
+### Problem
+
+Busy people (e.g. small online business owners, professionals with families)
+don't have time to handle the many miscellaneous tasks that crowd their lives:
+pay a medical bill, renew a vehicle registration, re-order printing paper, or
+sign up for a new credit card deal. They aren't big or important enough to hire
+someone to do, but they have an out-sized cost of stress and distraction in
+their lives, often get procrastinated, and can become big problems if neglected
+too long.
+
+
+### Solution
+
+Runbook is an AI-driven tool that lets any user create a recipe -- a simple
+definition of steps -- to accomplish almost any task on the web. These recipes,
+shared among users, allow any user to execute complex tasks with a single click,
+or schedule tasks to run in the future or on a recurring basis. With Runbook,
+entire workloads can be automated away.
+
+
+### Target Market
+
+Online business owners are the "beachhead" target market. They have many basic
+and complex web tasks associated with their workday, are accustomed to using
+software tools to streamline their work, and are willing to pay for effective
+software that saves them time and headache.
+
+Growth markets include busy young and middle-aged professionals, who have big
+constraints on their time and are comfortable using and paying for new
+technology.
+
+
+### Business Model
+
+Runbook has a usage-based pricing model: your first X tasks per month are free,
+and then $Y per 10 tasks after that; or similar tiered pricing model.
+
+
+### Why Gitcorp?
+
+Gitcorp is scratching its own itch: we aspire to automate as much of our own
+business processes as possible; Runbook is a tool that will help Gitcorp achieve
+that goal. Additionally, the Runbook recipe database will benefit from the
+engagement of Gitcorp's open community, and help provide a defensible network of
+content and users.
+
+
+### Existing solutions
+
+- Browser automation frameworks: Selenium, Nightmare, Puppeteer, etc.
+- Robotic Process Automation providers: NICE, Automation Anywhere, UiPath, etc.
+- Hiring a virtual or personal assistant
+

--- a/planning/proposals/props/prop-0001.md
+++ b/planning/proposals/props/prop-0001.md
@@ -24,8 +24,11 @@ too long.
 Runbook is an AI-driven tool that lets any user create a recipe -- a simple
 definition of steps -- to accomplish almost any task on the web. These recipes,
 shared among users, allow any user to execute complex tasks with a single click,
-or schedule tasks to run in the future or on a recurring basis. With Runbook,
-entire workloads can be automated away.
+or schedule tasks to run in the future or on a recurring basis. Runbook uses AI
+to parse web pages intelligently so it understands the semantics and roles of
+all elements on the page, allowing users to give it simple, plain-english
+commands like "create account" or "purchase the basic subscription". With
+Runbook, entire workloads can be automated away.
 
 ### Target market
 

--- a/planning/proposals/props/prop-0001.md
+++ b/planning/proposals/props/prop-0001.md
@@ -9,7 +9,6 @@
 
 #### One click recipes to automate any web task
 
-
 ### Problem
 
 Busy people (e.g. small online business owners, professionals with families)
@@ -20,7 +19,6 @@ someone to do, but they have an out-sized cost of stress and distraction in
 their lives, often get procrastinated, and can become big problems if neglected
 too long.
 
-
 ### Solution
 
 Runbook is an AI-driven tool that lets any user create a recipe -- a simple
@@ -29,8 +27,7 @@ shared among users, allow any user to execute complex tasks with a single click,
 or schedule tasks to run in the future or on a recurring basis. With Runbook,
 entire workloads can be automated away.
 
-
-### Target Market
+### Target market
 
 Online business owners are the "beachhead" target market. They have many basic
 and complex web tasks associated with their workday, are accustomed to using
@@ -41,12 +38,10 @@ Growth markets include busy young and middle-aged professionals, who have big
 constraints on their time and are comfortable using and paying for new
 technology.
 
-
-### Business Model
+### Business model
 
 Runbook has a usage-based pricing model: your first X tasks per month are free,
 and then $Y per 10 tasks after that; or similar tiered pricing model.
-
 
 ### Why Gitcorp?
 
@@ -55,7 +50,6 @@ business processes as possible; Runbook is a tool that will help Gitcorp achieve
 that goal. Additionally, the Runbook recipe database will benefit from the
 engagement of Gitcorp's open community, and help provide a defensible network of
 content and users.
-
 
 ### Existing solutions
 


### PR DESCRIPTION
Reminder from PROP guidelines: "Discussion on the merge request should focus on making the proposal the best version of itself possible. Discussion of whether or not it's the right
product for Gitcorp is *prohibited* -- such discussion should be saved for the
Member Vote. Valid reasons a PROP merge request may be declined include:
duplicate idea, insufficient or improper specification, poorly thought-out
proposal; invalid reasons include: perception of the quality of the idea, doubts
about its marketability, etc."