### PR TITLE
PROP-0002 -- Gremlins

### DIFF
--- a/planning/proposals/props/prop-0002.md
+++ b/planning/proposals/props/prop-0002.md
@@ -1,0 +1,46 @@
+<pre>
+    Title: PROP 2 -- Gremlins
+    Author: @kvh
+    Status: Active
+</pre>
+
+
+## Gremlins
+
+#### No bug left uncovered. One-click, no-setup QA.
+
+### Problem
+
+Website QA is expensive. Fast moving teams with dynamic products want assurance
+that they haven't broken critical functionality, but automated QA is limited and
+brittle and manual QA is expensive.
+
+### Solution
+
+Gremlins is a one-click, no-setup QA solution. It uses AI to intelligently
+navigate any site or app: filling forms, following flows, and engaging with
+the entire site experience automatically, reporting any user errors,
+inconsistencies, or visual defects as it goes.
+
+### Target market
+
+Small/medium SaaS companies who are not big enough to support a full-time QA
+team and want to iterate quickly without breaking things.
+
+### Business model
+
+Subscription pricing tiered by frequency of scans, size of site, and/or
+comprehensiveness of scan.
+
+### Why Gitcorp?
+
+Gitcorp is scratching its own itch: we aspire to automate as much of our own
+business processes as possible; Gremlins is a tool that will help Gitcorp
+achieve that goal. Additionally, Gitcorp has brand awareness in the target
+market.
+
+### Existing solutions
+
+- Manual QA
+- Automated browser testing: Selenium, Nightmare, Puppeteer, etc.
+


### PR DESCRIPTION
Reminder from PROP guidelines: "Discussion on the merge request should focus on making the proposal the best version of itself possible. Discussion of whether or not it's the right
product for Gitcorp is prohibited -- such discussion should be saved for the
Member Vote. Valid reasons a PROP merge request may be declined include:
duplicate idea, insufficient or improper specification, poorly thought-out
proposal; invalid reasons include: perception of the quality of the idea, doubts
about its marketability, etc."